### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ stations
 
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/gersolar/stations?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-[![License](https://pypip.in/license/stations/badge.svg)](https://pypi.python.org/pypi/stations/) [![Downloads](https://pypip.in/download/stations/badge.svg)](https://pypi.python.org/pypi/stations/) [![Build Status](https://travis-ci.org/gersolar/stations.svg?branch=master)](https://travis-ci.org/gersolar/stations) [![Coverage Status](https://coveralls.io/repos/gersolar/stations/badge.png)](https://coveralls.io/r/gersolar/stations) [![Code Health](https://landscape.io/github/gersolar/stations/master/landscape.png)](https://landscape.io/github/gersolar/stations/master) [![PyPI version](https://badge.fury.io/py/stations.svg)](http://badge.fury.io/py/stations)
-[![Supported Python versions](https://pypip.in/py_versions/stations/badge.svg)](https://pypi.python.org/pypi/stations/) [![Stories in Ready](https://badge.waffle.io/gersolar/stations.png?label=ready&title=Ready)](https://waffle.io/gersolar/stations)
+[![License](https://img.shields.io/pypi/l/stations.svg)](https://pypi.python.org/pypi/stations/) [![Downloads](https://img.shields.io/pypi/dm/stations.svg)](https://pypi.python.org/pypi/stations/) [![Build Status](https://travis-ci.org/gersolar/stations.svg?branch=master)](https://travis-ci.org/gersolar/stations) [![Coverage Status](https://coveralls.io/repos/gersolar/stations/badge.png)](https://coveralls.io/r/gersolar/stations) [![Code Health](https://landscape.io/github/gersolar/stations/master/landscape.png)](https://landscape.io/github/gersolar/stations/master) [![PyPI version](https://badge.fury.io/py/stations.svg)](http://badge.fury.io/py/stations)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/stations.svg)](https://pypi.python.org/pypi/stations/) [![Stories in Ready](https://badge.waffle.io/gersolar/stations.png?label=ready&title=Ready)](https://waffle.io/gersolar/stations)
 
 Stations is a python service that provides you a sensed data database. It also, manage an inventory of the field devices (including sensors and calibrations).
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20stations))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `stations`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.